### PR TITLE
Changing `council_district` to `ward` in 298 in GoogleCivicInformation.php

### DIFF
--- a/api/v3/GoogleCivicInformation.php
+++ b/api/v3/GoogleCivicInformation.php
@@ -295,7 +295,7 @@ function google_civic_information_city_districts($level, $limit, $update) {
         $divisionDistrict = ''; 
         $divisionParts = explode('/', str_replace($cityDivision . '/', '', $divisionKey));
         if(substr($divisionParts[0], 0, 5) == 'place' &&
-           substr($divisionParts[1], 0, 16) == 'council_district' &&
+           substr($divisionParts[1], 0, 16) == 'ward' &&
            in_array(substr($divisionParts[0], 6), $cities)) {
            
           $city = ucwords(substr($divisionParts[0], 6));


### PR DESCRIPTION
A "fix" for #26 , it's not a permanent fix, but it will allow me to get the correct value for Wards for cities like Santa Ana, CA; Chicago, IL that have `wards` as the OCDID name not `council_districts` as NYC does. I think :). 